### PR TITLE
Change port to greater than 1023 due to Fargate restriction

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -140,7 +140,7 @@ jobs:
           openssl req -x509 -newkey rsa:2048 \
             -keyout docker/certs/haproxy-key.pem \
             -out docker/certs/haproxy-cert.pem \
-            -days 365 -nodes -subj "/CN=localhost"
+            -days 365 -nodes -subj "/CN=nginx.react-app.local"
           cat docker/certs/haproxy-cert.pem docker/certs/haproxy-key.pem > docker/certs/haproxy.pem
 
       - name: Build and push ${{ matrix.service.name }} image

--- a/docker/Dockerfile.haproxy
+++ b/docker/Dockerfile.haproxy
@@ -6,12 +6,12 @@ COPY docker/haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
 # Copy certificates - ensure docker/certs directory exists before building
 # Run: mkdir -p docker/certs && cd docker/certs && \
 #      openssl req -x509 -newkey rsa:2048 -keyout haproxy-key.pem -out haproxy-cert.pem \
-#      -days 365 -nodes -subj "/CN=localhost" && \
+#      -days 365 -nodes -subj "/CN=nginx.react-app.local" && \
 #      cat haproxy-cert.pem haproxy-key.pem > haproxy.pem
 COPY docker/certs/haproxy.pem /usr/local/etc/haproxy/certs/haproxy.pem
 
-# Expose ports (80 for HTTP redirect, 443 for HTTPS)
-EXPOSE 80 443
+# Expose ports (8080 for HTTP redirect, 8443 for HTTPS)
+EXPOSE 8080 8443
 
 # Run HAProxy
-CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg", "-db"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/docker/haproxy.cfg
+++ b/docker/haproxy.cfg
@@ -48,7 +48,7 @@ defaults
     errorfile 504 /dev/null
 
 frontend http_in
-    bind *:80
+    bind *:8080
     
     # Health check endpoint (before redirect)
     # This allows monitoring systems to check HAProxy without requiring SSL
@@ -58,7 +58,7 @@ frontend http_in
     http-request redirect scheme https code 301
 
 frontend https_in
-    bind *:443 ssl crt /usr/local/etc/haproxy/certs/haproxy.pem
+    bind *:8443 ssl crt /usr/local/etc/haproxy/certs/haproxy.pem
     
     # Security headers
     http-response set-header X-Frame-Options SAMEORIGIN

--- a/iac/src/cloud/aws/ecs.ts
+++ b/iac/src/cloud/aws/ecs.ts
@@ -1,8 +1,8 @@
 import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
-// Health check port preference: use port 80 when available for non-SSL health checks
-const PREFERRED_HEALTH_CHECK_PORT = 80;
+// Health check port preference: use port 8080 when available for non-SSL health checks
+const PREFERRED_HEALTH_CHECK_PORT = 8080;
 
 interface EcsClusterConfig {
   name?: string;

--- a/iac/src/cloud/aws/vpc.ts
+++ b/iac/src/cloud/aws/vpc.ts
@@ -143,14 +143,14 @@ export function createVpc(config: VpcConfig = {}): VpcResources {
     ingress: [
       {
         protocol: "tcp",
-        fromPort: 80,
-        toPort: 80,
+        fromPort: 8080,
+        toPort: 8080,
         cidrBlocks: ["0.0.0.0/0"],
       },
       {
         protocol: "tcp",
-        fromPort: 443,
-        toPort: 443,
+        fromPort: 8443,
+        toPort: 8443,
         cidrBlocks: ["0.0.0.0/0"],
       },
       {

--- a/iac/src/deployment/react-service.ts
+++ b/iac/src/deployment/react-service.ts
@@ -65,8 +65,8 @@ export class ReactService extends Service {
       clusterArn: ecsCluster.arn,
       serviceName: "haproxy-service",
       imageUri: haproxyImageUri,
-      containerPort: 443, // Primary HTTPS port
-      additionalPorts: [80], // HTTP port for redirect
+      containerPort: 8443, // Primary HTTPS port
+      additionalPorts: [8080], // HTTP port for redirect
       containerMemory: 512,
       containerCpu: 256,
       desiredCount: 1,


### PR DESCRIPTION
This pull request updates the HAProxy configuration and related infrastructure to use ports 8080 (HTTP) and 8443 (HTTPS) instead of the standard 80/443, and updates the SSL certificate subject for local development. These changes ensure consistency across Docker, HAProxy, and infrastructure-as-code (IaC) configurations.

**Port changes (from 80/443 to 8080/8443):**

* Updated exposed ports in `docker/Dockerfile.haproxy` to 8080 and 8443, and removed the `-db` flag from the HAProxy command.
* Changed HAProxy bindings in `docker/haproxy.cfg` to use 8080 for HTTP and 8443 for HTTPS. [[1]](diffhunk://#diff-71ef3ca9cda37fc63a8df06208b21dea46af725371b64731ebc34842eaf2382eL51-R51) [[2]](diffhunk://#diff-71ef3ca9cda37fc63a8df06208b21dea46af725371b64731ebc34842eaf2382eL61-R61)
* Updated ECS service configuration in `iac/src/deployment/react-service.ts` to use 8443 as the primary container port and 8080 as the additional HTTP port.
* Modified VPC security group rules in `iac/src/cloud/aws/vpc.ts` to allow ingress on ports 8080 and 8443 instead of 80 and 443.
* Changed the preferred health check port in `iac/src/cloud/aws/ecs.ts` from 80 to 8080.

**SSL certificate configuration:**

* Updated the OpenSSL certificate subject in `.github/workflows/build-push-images.yml` and the corresponding Dockerfile comment to use `/CN=nginx.react-app.local` for local development instead of `/CN=localhost`. [[1]](diffhunk://#diff-fcb6cba2bb80de99b275501bc3379e852737a415e9aef4c129ecea0aa03b53daL143-R143) [[2]](diffhunk://#diff-fe3efbbb95e0470e0cddae34ea1d13a49680ffcd2104a59eb496e85853921614L9-R17)